### PR TITLE
fix bug in autoplot with factor followed by numeric; closes #79

### DIFF
--- a/R/autoplot.R
+++ b/R/autoplot.R
@@ -386,11 +386,10 @@ ggplot_two_predictor_pdp <- function(
       if (is.null(train)) {
         stop("The training data must be supplied for rug display.")
       } else {
-        x.name <- which(names(train) == names(object)[[2L]])
-        x.rug <- data.frame(as.numeric(
-          stats::quantile(train[, x.name, drop = TRUE], probs = 0:10/10,
+        x.rug <- data.frame(quants = as.numeric(
+          stats::quantile(train[[non_factor_cols]], probs = 0:10/10,
                           na.rm = TRUE)))
-        p <- p + geom_rug(data = x.rug, aes(x = x.rug[[1L]]), sides = "b",
+        p <- p + geom_rug(data = x.rug, aes_string(x = "quants"), sides = "b",
                           inherit.aes = FALSE)
       }
     }


### PR DESCRIPTION
Please let me know what you think.

``` r
suppressPackageStartupMessages(library(ggplot2))
suppressPackageStartupMessages(library(pdp))
suppressPackageStartupMessages(library(randomForest))

set.seed(101)

data(boston)
boston[["foo"]] <- factor(sample(c("a", "b"), nrow(boston), replace = TRUE))

boston.rf <- randomForest(cmedv ~ ., data = boston)

# zero factors
boston.rf %>%
  partial(pred.var = c("age", "lstat"), chull = TRUE) %>%
  autoplot(contour = TRUE, main = "numeric/numeric")
```

![](https://i.imgur.com/m2HvVQ5.png)

``` r

# one factor
boston.rf %>%
  partial(pred.var = c("chas", "lstat"), chull = TRUE) %>%
  autoplot(contour = TRUE, main = "factor/numeric")
```

![](https://i.imgur.com/Aj5OFlA.png)

``` r

boston.rf %>%
  partial(pred.var = c("lstat", "chas"), chull = TRUE) %>%
  autoplot(contour = TRUE, main = "numeric/factor")
```

![](https://i.imgur.com/nl8drty.png)

``` r

# two factors
boston.rf %>%
  partial(pred.var = c("foo", "chas"), chull = TRUE) %>%
  autoplot(contour = TRUE, main = "factor/factor")
```

![](https://i.imgur.com/psmN0pW.png)

Created on 2018-08-31 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).