### PR TITLE
Prioritize pdp specific classes over data.frame

### DIFF
--- a/R/partial.R
+++ b/R/partial.R
@@ -432,7 +432,7 @@ partial.default <- function(
     # Use Friedman's weighted tree traversal approach
     pd.df <- getParDepGBM(object, pred.var = pred.var, pred.grid = pred.grid,
                           which.class = which.class, prob = prob, ...)
-    class(pd.df) <- c("data.frame", "partial")  # assign class labels
+    class(pd.df) <- c("partial", "data.frame")  # assign class labels
     names(pd.df) <- c(pred.var, "yhat")  # rename columns
     rownames(pd.df) <- NULL  # remove row names
 
@@ -480,7 +480,7 @@ partial.default <- function(
       names(pd.df)[ncol(pd.df)] <- "yhat.id"  # rename "time" column
 
       # Assign class labels
-      class(pd.df) <- c("data.frame", "ice")
+      class(pd.df) <- c("ice", "data.frame")
 
       # c-ICE curves
       if (center) {
@@ -493,7 +493,7 @@ partial.default <- function(
 
     } else {  # single curve
       names(pd.df) <- c(pred.var, "yhat")  # rename columns
-      class(pd.df) <- c("data.frame", "partial")  # assign class labels
+      class(pd.df) <- c("partial", "data.frame")  # assign class labels
     }
     rownames(pd.df) <- NULL  # remove row names
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,7 +88,7 @@ center_ice_curves.ice <- function(object) {
     "yhat.id" = object["yhat.id"]
   )
   names(res)[1L] <- names(object)[1L]
-  class(res) <- c("data.frame", "cice")
+  class(res) <- c("cice", "data.frame")
   res
 }
 


### PR DESCRIPTION
Currently, results from the pdp package has class like `c("data.frame", "partial")`.
This is not robust to the conflict of S3 methods because a method for data.frame has priority to methods for pdp specific classes.
For example, if I define `autoplot.data.frame`, it is used instead of `autoplot.partial` by `partial(plot = TRUE, plot.engine = "ggplot2")`.
This PR fixes the problem by prioritizing pdp specific classes over data.frame (e.g., `c("partial", "data.frame")`)

``` r
library(pdp)
library(randomForest)
#> randomForest 4.6-14
#> Type rfNews() to see new features/changes/bug fixes.
data (boston)  # load the boston housing data
set.seed(101)  # for reproducibility
boston.rf <- randomForest(cmedv ~ ., data = boston)

partial(boston.rf, pred.var = "lstat", plot = TRUE, plot.engine = "ggplot2", rug = TRUE)
```

![](https://i.imgur.com/sXlOwps.png)

``` r

autoplot.data.frame <- function(object, ...) stop()
partial(boston.rf, pred.var = "lstat", plot = TRUE, plot.engine = "ggplot2", rug = TRUE)
#> Error in autoplot.data.frame(object = pd.df, smooth = smooth, rug = rug, :
```

<sup>Created on 2019-11-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>